### PR TITLE
Create bash-completion.sh

### DIFF
--- a/bash-completion.sh
+++ b/bash-completion.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 
-# Make the .config/ziggy directory
-mkdir -p ~/.config/ziggy
+# Remove the existing .config/ziggy directory if it exists
+rm -rf ~/.config/ziggy
+
+# Make the .config/ziggy directory and navigate to
+mkdir ~/.config/ziggy && cd ~/.config/ziggy
 
 # Download the _zig file to the .config/ziggy directory
-curl https://raw.githubusercontent.com/ziglang/shell-completions/master/_zig -o ~/.config/ziggy/_zig
+wget https://raw.githubusercontent.com/Byte-Cats/shell-completions/master/_zig
 
-# Add the .config/ziggy directory to the $fpath
-echo "source \"~/.config/ziggy/_zig\"" >> /.bashrc
+# Add the .config/ziggy directory to the $fpath, remove duplicates
+echo "fpath=(~/.config/ziggy \$fpath)" >> ~/.bashrc
+sed -i '$!N; /^\(.*\)\n\1$/!P; D' ~/.bashrc
 
 # Source the ~/.bashrc file to update the current terminal
 source ~/.bashrc

--- a/bash-completion.sh
+++ b/bash-completion.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Make the .config/ziggy directory
+mkdir -p ~/.config/ziggy
+
+# Download the _zig file to the .config/ziggy directory
+curl https://raw.githubusercontent.com/ziglang/shell-completions/master/_zig -o ~/.config/ziggy/_zig
+
+# Add the .config/ziggy directory to the $fpath
+echo "fpath=(~/.config/ziggy \$fpath)" >> ~/.bashrc
+
+# Source the ~/.bashrc file to update the current terminal
+source ~/.bashrc

--- a/bash-completion.sh
+++ b/bash-completion.sh
@@ -7,7 +7,7 @@ mkdir -p ~/.config/ziggy
 curl https://raw.githubusercontent.com/ziglang/shell-completions/master/_zig -o ~/.config/ziggy/_zig
 
 # Add the .config/ziggy directory to the $fpath
-echo "fpath=(~/.config/ziggy \$fpath)" >> ~/.bashrc
+echo "source \"~/.config/ziggy/_zig\"" >> /.bashrc
 
 # Source the ~/.bashrc file to update the current terminal
 source ~/.bashrc


### PR DESCRIPTION
# bash completion install script
## for bash based shell
## Proposed Instructions:

make bash_completion.sh file executable with `chmod +x bash_completion.sh`, and then run it with `./bash_completion.sh`. 

# what does this script do? 
This will create the `.config/ziggy directory`, download the `_zig` file to the `.config/ziggy` directory, add the `.config/ziggy` directory to the `$fpath`, and source the `~/.bashrc` file to update the current terminal.

Just like the installation readme but will do the same work but only using one command