### PR TITLE
Improve compatibility with non-linux systems

### DIFF
--- a/_zig
+++ b/_zig
@@ -271,7 +271,7 @@ __zig_build() {
         continue
       fi
       #  step (default)     description  -> step:(default) description
-      steps+=("$(sed -r 's/\s*(\S+)\s+(\(default\) )?\s+([^\s].*)/\1:\2\3/' <<<"$line")")
+      steps+=("$(sed -r 's/^ *([^ ]+)( \(default\))? +(.*) *$/\1:\3\2/' <<<"$line")")
     elif [ "$in_project_options" = "false" ]; then
       if [ "$line" = "Project-Specific Options:" ]; then
         in_project_options=true
@@ -280,7 +280,7 @@ __zig_build() {
     else
       if [ -n "$(grep '  -' <<<"$line")" ]; then
         #  -Dflag=[arg]       description -> -Dflag=[description]:arg
-        args+=("$(sed -r "s/  ([^\[ ]+) ?(\[([^]]*)\])?\s*(.+)/\1[\4]:\3/" <<<"$line")")
+        args+=("$(sed -r 's/^ *([^\[ ]+) ?(\[([^]]*)\])? *(.+) *$/\1[\4]:\3/' <<<"$line")")
       fi
     fi
   done <<< $help

--- a/_zig
+++ b/_zig
@@ -271,21 +271,21 @@ __zig_build() {
         continue
       fi
       #  step (default)     description  -> step:(default) description
-      steps+=("$(echo "$line" | sed -r 's/\s*(\S+)\s+(\(default\) )?\s+([^\s].*)/\1:\2\3/')")
+      steps+=("$(sed -r 's/\s*(\S+)\s+(\(default\) )?\s+([^\s].*)/\1:\2\3/' <<<"$line")")
     elif [ "$in_project_options" = "false" ]; then
       if [ "$line" = "Project-Specific Options:" ]; then
         in_project_options=true
         continue
       fi
     else
-      if [ -n "$(echo "$line" | grep '  -')" ]; then
+      if [ -n "$(grep '  -' <<<"$line")" ]; then
         #  -Dflag=[arg]       description -> -Dflag=[description]:arg
-        args+=("$(echo "$line" | sed -r "s/  ([^\[ ]+) ?(\[([^]]*)\])?\s*(.+)/\1[\4]:\3/")")
+        args+=("$(sed -r "s/  ([^\[ ]+) ?(\[([^]]*)\])?\s*(.+)/\1[\4]:\3/" <<<"$line")")
       fi
     fi
   done <<< $help
 
-  if [ -z "$(/usr/bin/echo $words[$CURRENT] | grep "^-")" ]; then
+  if [ -z "$(grep "^-" <<<$words[$CURRENT])" ]; then
     _describe 'step' steps
   else
     _arguments ${args[@]}


### PR DESCRIPTION
There were a few instances where sed was used with patterns that are incompatible with non-gnu sed. The whitespace character classes `\s` and `\S` were changed to ` ` and `[^ ]` respectively. This could use `[[:space:]]` and `[^[:space:]]` instead to be even more robust, but I saw no need.

Input to sed was being piped in with echo, which isn't necessarily a problem, as in bash and zsh echo is a shell builtin, BUT there was one instance where echo was hardcoded as `/usr/bin/echo`, which uses the external command. This is not present on some systems or in a different location. As a solution, I just changed all the usages of echo to use a here-string which removes the need for the pipe and negates any concern with cross-compatibility.