### PR TITLE
Adds zig build options introduced in version 0.13.0 and 0.14.0 and adds completions for steps other than [un]install test and run

### DIFF
--- a/_zig.bash
+++ b/_zig.bash
@@ -54,6 +54,13 @@ _zig_comp_util_get_varname ()
     echo "${encoded}"
 }
 
+_zig_comp_reply_build_steps ()
+{
+    local words=($(zig build --list-steps 2> /dev/null | grep -Eo '^\s*\w+' | grep -Eo '\w+'));
+    [ $? = 0 ] || return 1;
+    COMPREPLY=($(compgen -W "${words[*]}" -- "$cur"))
+}
+
 _zig_comp_reply_dirs ()
 {
     local IFS=$'\n';
@@ -167,7 +174,7 @@ _zig_completions_build() {
     _zig_comp_equal_sign_subcmd_opts_build "${COMP_WORDS[$(( COMP_CWORD - 2 ))]}"
   else
     # rely the argument of command
-    _zig_comp_reply_words 'install,uninstall,run,test'
+    _zig_comp_reply_build_steps
   fi
 }
 

--- a/_zig.bash
+++ b/_zig.bash
@@ -27,7 +27,7 @@ _zig_comp_subcmd_opts_ar=( --format --plugin= -h --help --output --rsp-quoting -
 
 _zig_comp_subcmd_opts_ast_check=( -h --help --color -t )
 
-_zig_comp_subcmd_opts_build=( -p --prefix --prefix-lib-dir --prefix-exe-dir --prefix-include-dir --release= -fdarling -fno-darling -fqemu -fno-qemu --glibc-runtimes -frosetta -fno-rosetta -fwasmtime -fno-wasmtime -fwine -fno-wine -h --help -l, --list-steps --verbose --color --prominent-compile-errors --summary --j --maxrss --fetch -Dtarget= -Dcpu= -Ddynamic-linker= -Doptimize= --search-prefix --sysroot --libc --system -fsys= -fno-sys= -freference-trace -fno-reference-trace --build-file --cache-dir --global-cache-dir --zig-lib-dir --build-runner --seed --debug-log --debug-pkg-config --verbose-link --verbose-air --verbose-llvm-ir --verbose-llvm-bc= --verbose-cimport --verbose-cc --verbose-llvm-cpu-features )
+_zig_comp_subcmd_opts_build=( -p --prefix --prefix-lib-dir --prefix-exe-dir --prefix-include-dir --release= -fdarling -fno-darling -fqemu -fno-qemu --glibc-runtimes -frosetta -fno-rosetta -fwasmtime -fno-wasmtime -fwine -fno-wine -h --help -l, --list-steps --verbose --color --prominent-compile-errors --summary -j --maxrss --fetch -Dtarget= -Dcpu= -Ddynamic-linker= -Doptimize= --search-prefix --sysroot --libc --system -fsys= -fno-sys= -freference-trace -fno-reference-trace --build-file --cache-dir --global-cache-dir --zig-lib-dir --build-runner --seed --debug-log --debug-pkg-config --verbose-link --verbose-air --verbose-llvm-ir --verbose-llvm-bc= --verbose-cimport --verbose-cc --verbose-llvm-cpu-features )
 
 _zig_comp_subcmd_opts_build_fallback=( @files )
 
@@ -115,7 +115,7 @@ _zig_comp_reply_zig_file() {
   _zig_comp_reply_files_in_pattern '\.(zig|zir|zon|o|obj|lib|a|so|dll|dylib|tbd|s|S|c|cxx|cc|C|cpp|stub|m|mm|bc|cu)$'
 }
 
-_zig_comp_subcmds=( build fetch init build-exe build-lib build-obj test run ast-check fmt reduce translate-c ar cc c++ dlltool lib ranlib rc env help std libc targets version zen )
+_zig_comp_subcmds=( build fetch init build-exe build-lib build-obj test run ast-check fmt reduce translate-c ar cc c++ dlltool lib ranlib objcopy rc env help std libc targets version zen )
 
 _zig_comp_equal_sign_subcmd_opts_build() {
   case "${1}=" in
@@ -147,6 +147,7 @@ _zig_completions_build() {
       --prefix-include-dir) _zig_comp_reply_dirs ;;
       --color) _zig_comp_reply_words 'auto,off,on' ;;
       --summary) _zig_comp_reply_words 'all,new,failures,none' ;;
+      -j)  ;;
       --maxrss)  ;;
       --search-prefix) _zig_comp_reply_dirs ;;
       --sysroot) _zig_comp_reply_dirs ;;

--- a/_zig.bash
+++ b/_zig.bash
@@ -27,7 +27,7 @@ _zig_comp_subcmd_opts_ar=( --format --plugin= -h --help --output --rsp-quoting -
 
 _zig_comp_subcmd_opts_ast_check=( -h --help --color -t )
 
-_zig_comp_subcmd_opts_build=( -p --prefix --prefix-lib-dir --prefix-exe-dir --prefix-include-dir --release= -fdarling -fno-darling -fqemu -fno-qemu --glibc-runtimes -frosetta -fno-rosetta -fwasmtime -fno-wasmtime -fwine -fno-wine -h --help -l, --list-steps --verbose --color --prominent-compile-errors --summary -j --maxrss --fetch -Dtarget= -Dcpu= -Ddynamic-linker= -Doptimize= --search-prefix --sysroot --libc --system -fsys= -fno-sys= -freference-trace -fno-reference-trace --build-file --cache-dir --global-cache-dir --zig-lib-dir --build-runner --seed --debug-log --debug-pkg-config --verbose-link --verbose-air --verbose-llvm-ir --verbose-llvm-bc= --verbose-cimport --verbose-cc --verbose-llvm-cpu-features )
+_zig_comp_subcmd_opts_build=( -p --prefix --prefix-lib-dir --prefix-exe-dir --prefix-include-dir --release= -fdarling -fno-darling -fqemu -fno-qemu --glibc-runtimes -frosetta -fno-rosetta -fwasmtime -fno-wasmtime -fwine -fno-wine -h --help -l --list-steps --verbose --color --prominent-compile-errors --summary -j --maxrss --skip-oom-steps --fetch --watch --fuzz --debounce -fincremental -fno-incremental -Dtarget= -Dcpu= -Dofmt= -Ddynamic-linker= -Doptimize= --search-prefix --sysroot --libc --system -fsys= -fno-sys= -freference-trace -fno-reference-trace --build-file --cache-dir --global-cache-dir --zig-lib-dir --build-runner --seed --debug-log --debug-pkg-config --debug-rt --verbose-link --verbose-air --verbose-llvm-ir --verbose-llvm-bc= --verbose-cimport --verbose-cc --verbose-llvm-cpu-features )
 
 _zig_comp_subcmd_opts_build_fallback=( @files )
 
@@ -122,11 +122,12 @@ _zig_comp_equal_sign_subcmd_opts_build() {
     --release=) _zig_comp_reply_words 'fast,safe,small' ;;
     -Dtarget=)  ;;
     -Dcpu=)  ;;
+    -Dofmt=)  ;;
     -Ddynamic-linker=)  ;;
     -Doptimize=) _zig_comp_reply_words 'Debug,ReleaseSafe,ReleaseFast,ReleaseSmall' ;;
     -fsys=)  ;;
     -fno-sys=)  ;;
-    --verbose-llvm-bc=)  ;;
+    --verbose-llvm-bc=) _zig_comp_reply_files ;;
   esac
 }
 
@@ -149,6 +150,7 @@ _zig_completions_build() {
       --summary) _zig_comp_reply_words 'all,new,failures,none' ;;
       -j)  ;;
       --maxrss)  ;;
+      --debounce)  ;;
       --search-prefix) _zig_comp_reply_dirs ;;
       --sysroot) _zig_comp_reply_dirs ;;
       --system) _zig_comp_reply_dirs ;;
@@ -158,6 +160,7 @@ _zig_completions_build() {
       --zig-lib-dir) _zig_comp_reply_dirs ;;
       --seed)  ;;
       --debug-log)  ;;
+      --verbose-llvm-ir)  ;;
       *) _zig_comp_reply_files ;;
     esac
   elif [[ ${prev} == = ]]; then

--- a/zig.completor.bash
+++ b/zig.completor.bash
@@ -43,17 +43,23 @@ subcmd_opts_build=(
   -fwine -fno-wine
 
   -h --help
-  -l, --list-steps
+  -l --list-steps
   --verbose
   --color:'auto,off,on'
   --prominent-compile-errors
   --summary:'all,new,failures,none'
   -j:@hold
   --maxrss:@hold
+  --skip-oom-steps
   --fetch
+  --watch
+  --fuzz
+  --debounce:@hold
+  -fincremental -fno-incremental
 
   -Dtarget=
   -Dcpu=
+  -Dofmt=
   -Ddynamic-linker=
   -Doptimize=:'Debug,ReleaseSafe,ReleaseFast,ReleaseSmall'
 
@@ -76,10 +82,11 @@ subcmd_opts_build=(
 
   --debug-log:@hold
   --debug-pkg-config
+  --debug-rt
   --verbose-link
   --verbose-air
-  --verbose-llvm-ir
-  --verbose-llvm-bc=
+  --verbose-llvm-ir:@hold
+  --verbose-llvm-bc=:@files
   --verbose-cimport
   --verbose-cc
   --verbose-llvm-cpu-features

--- a/zig.completor.bash
+++ b/zig.completor.bash
@@ -48,7 +48,7 @@ subcmd_opts_build=(
   --color:'auto,off,on'
   --prominent-compile-errors
   --summary:'all,new,failures,none'
-  --j
+  -j:@hold
   --maxrss:@hold
   --fetch
 

--- a/zig.completor.bash
+++ b/zig.completor.bash
@@ -11,7 +11,7 @@ subcmds=(
   build fetch init
   build-exe build-lib build-obj test run
   ast-check fmt reduce translate-c
-  ar cc c++ dlltool lib ranlib rc
+  ar cc c++ dlltool lib ranlib objcopy rc
   env help std libc targets version zen
 )
 

--- a/zig.completor.bash
+++ b/zig.completor.bash
@@ -24,6 +24,14 @@ reply_zig_file=(
   '\.(zig|zir|zon|o|obj|lib|a|so|dll|dylib|tbd|s|S|c|cxx|cc|C|cpp|stub|m|mm|bc|cu)$'
 )
 
+reply_build_steps() {
+  local words=( $(zig build --list-steps 2>/dev/null | grep -Eo '^\s*\w+' | grep -Eo '\w+') )
+  
+  [ $? = 0 ] || return 1
+
+  COMPREPLY=( $(compgen -W "${words[*]}" -- "$cur") )
+}
+
 subcmd_opts__fallback='--help'
 
 subcmd_opts_build=(
@@ -92,7 +100,8 @@ subcmd_opts_build=(
   --verbose-llvm-cpu-features
 )
 # https://ziglearn.org/chapter-3/#build-steps
-subcmd_args_build='install,uninstall,run,test'
+subcmd_args_build=@build_steps
+subcmd_args_build_fallback='install,uninstall,run,test'
 subcmd_opts_build_fallback=@files
 
 subcmd_opts_fmt=(


### PR DESCRIPTION
Hi there, i've added bash completions for `zig build` options introduced in 0.13.0 and 0.14.0.
I've also implemented a reply action listing all the steps. I have tested the functionality localy on a private project and it did work, but please have at least a look at the reply action since i am a novice. I only used grep and obviously the zig compiler.
Hope yall have a nice day